### PR TITLE
Don't specify resolution.

### DIFF
--- a/main.c
+++ b/main.c
@@ -28,8 +28,6 @@ int main(void)
     lv_disp_drv_init(&disp_drv);
     disp_drv.draw_buf   = &disp_buf;
     disp_drv.flush_cb   = fbdev_flush;
-    disp_drv.hor_res    = 800;
-    disp_drv.ver_res    = 480;
     lv_disp_drv_register(&disp_drv);
 
     /*Create a Demo*/


### PR DESCRIPTION
Specifying the resolution is bad if it's wrong, and the fb driver autodetects
it in any case.