### PR TITLE
Define missing prototype for custom_tick_get()

### DIFF
--- a/lv_conf.h
+++ b/lv_conf.h
@@ -19,6 +19,12 @@
 
 #include <stdint.h>
 
+/*=======================
+   FUNCTION PROTOTYPES
+ *=======================*/
+
+extern uint32_t custom_tick_get(void);
+
 /*====================
    COLOR SETTINGS
  *====================*/


### PR DESCRIPTION
Clang 15+ is strict about missing protoypes.

Fixes #25

Signed-off-by: Khem Raj <raj.khem@gmail.com>