### PR TITLE
Makefile: Add the install/uninstall hooks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,8 @@ CFLAGS ?= -O3 -g0 -I$(LVGL_DIR)/ -Wall -Wshadow -Wundef -Wmissing-prototypes -Wn
 LDFLAGS ?= -lm
 BIN = demo
 
+prefix ?= /usr
+bindir ?= $(prefix)/bin
 
 #Collect the files to compile
 MAINSRC = ./main.c
@@ -41,3 +43,9 @@ default: $(AOBJS) $(COBJS) $(MAINOBJ)
 clean: 
 	rm -f $(BIN) $(AOBJS) $(COBJS) $(MAINOBJ)
 
+install:
+	install -d $(DESTDIR)$(bindir)
+	install $(BIN) $(DESTDIR)$(bindir)
+
+uninstall:
+	$(RM) -r $(addprefix $(DESTDIR)$(bindir)/,$(BIN))

--- a/README.md
+++ b/README.md
@@ -6,3 +6,26 @@ When cloning this repository, also make sure to download submodules (`git submod
 
 Check out this blog post for a step by step tutorial:
 https://blog.lvgl.io/2018-01-03/linux_fb
+
+## Clone the project
+
+Clone the LVGL Framebuffer Demo project and its related sub modules:
+
+```
+git clone https://github.com/lvgl/lv_port_linux_frame_buffer.git
+cd lv_port_linux_frame_buffer/
+git submodule update --init --recursive
+```
+
+## Build the project
+
+```
+make
+sudo make install
+```
+
+## Run the demo application
+
+```
+demo
+```


### PR DESCRIPTION
Improve the Makefile by adding the install/uninstall hooks.

This makes it easier for packaging the project when using OpenEmbedded, for example.

Signed-off-by: Fabio Estevam <festevam@denx.de>