### PR TITLE
Improve video device selection flexibility and add DRM/KMS and SDL2 backend support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,9 @@ target_include_directories(lvgl PUBLIC ${PROJECT_SOURCE_DIR})
 
 add_executable(main main.c mouse_cursor_icon.c)
 
-target_link_libraries(main lvgl lvgl::examples lvgl::demos lvgl::thorvg ${SDL2_LIBRARIES} m pthread)
+include(${CMAKE_CURRENT_LIST_DIR}/lvgl/tests/FindLibDRM.cmake)
+include_directories(${Libdrm_INCLUDE_DIRS})
+
+target_link_libraries(main lvgl lvgl::examples lvgl::demos lvgl::thorvg ${SDL2_LIBRARIES} ${Libdrm_LIBRARIES} m pthread)
 add_custom_target (run COMMAND ${EXECUTABLE_OUTPUT_PATH}/main DEPENDS main)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,10 @@ add_executable(main main.c mouse_cursor_icon.c)
 include(${CMAKE_CURRENT_LIST_DIR}/lvgl/tests/FindLibDRM.cmake)
 include_directories(${Libdrm_INCLUDE_DIRS})
 
-target_link_libraries(main lvgl lvgl::examples lvgl::demos lvgl::thorvg ${SDL2_LIBRARIES} ${Libdrm_LIBRARIES} m pthread)
+find_package(SDL2)
+find_package(SDL2_image)
+include_directories(${SDL2_INCLUDE_DIRS} ${SDL2_IMAGE_INCLUDE_DIRS})
+
+target_link_libraries(main lvgl lvgl::examples lvgl::demos lvgl::thorvg ${SDL2_LIBRARIES} ${SDL2_IMAGE_LIBRARIES} ${Libdrm_LIBRARIES} m pthread)
 add_custom_target (run COMMAND ${EXECUTABLE_OUTPUT_PATH}/main DEPENDS main)
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-# LVGL for frame buffer device
+# LVGL on top of Linux graphics stack
 
-Example project to use LVGL with a Linux frame buffer device,
-by default `/dev/fb0`.
+Example project to use LVGL on top of Linux graphics stack.
+Currently supported backends are either legacy framebuffer
+(fbdev) or modern DRM/KMS.
 
+By default, legacy framebuffer backend uses `/dev/fb0` device node,
+DRM/KMS backend uses '/dev/dri/card0' card node.
 
 Check out this blog post for a step by step tutorial:
 https://blog.lvgl.io/2018-01-03/linux_fb
@@ -15,6 +18,20 @@ Clone the LVGL Framebuffer Demo project and its related sub modules.
 git clone https://github.com/lvgl/lv_port_linux_frame_buffer.git
 cd lv_port_linux_frame_buffer/
 git submodule update --init --recursive
+```
+
+## Select graphics backend (optional)
+
+To use legacy framebuffer (fbdev) support, adjust `lv_conf.h` as follows:
+```
+#define LV_USE_LINUX_FBDEV	1
+#define LV_USE_LINUX_DRM	0
+```
+
+To use modern DRM/KMS support, adjust `lv_conf.h` as follows:
+```
+#define LV_USE_LINUX_FBDEV	0
+#define LV_USE_LINUX_DRM	1
 ```
 
 ## Build the project
@@ -34,6 +51,10 @@ The following variables are supported.
 ### Legacy framebuffer (fbdev)
 
 - `LV_LINUX_FBDEV_DEVICE` - override default (`/dev/fb0`) framebuffer device node.
+
+### DRM/KMS
+
+- `LV_LINUX_DRM_CARD` - override default (`/dev/dri/card0`) card.
 
 ## Run the demo application
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,11 @@
 
 Example project to use LVGL on top of Linux graphics stack.
 Currently supported backends are either legacy framebuffer
-(fbdev) or modern DRM/KMS.
+(fbdev), modern DRM/KMS, or SDL2.
 
 By default, legacy framebuffer backend uses `/dev/fb0` device node,
-DRM/KMS backend uses '/dev/dri/card0' card node.
+DRM/KMS backend uses '/dev/dri/card0' card node, SDL2 uses window
+resolution of 800x480.
 
 Check out this blog post for a step by step tutorial:
 https://blog.lvgl.io/2018-01-03/linux_fb
@@ -26,12 +27,21 @@ To use legacy framebuffer (fbdev) support, adjust `lv_conf.h` as follows:
 ```
 #define LV_USE_LINUX_FBDEV	1
 #define LV_USE_LINUX_DRM	0
+#define LV_USE_SDL		0
 ```
 
 To use modern DRM/KMS support, adjust `lv_conf.h` as follows:
 ```
 #define LV_USE_LINUX_FBDEV	0
 #define LV_USE_LINUX_DRM	1
+#define LV_USE_SDL		0
+```
+
+To use SDL2 support, adjust `lv_conf.h` as follows:
+```
+#define LV_USE_LINUX_FBDEV	0
+#define LV_USE_LINUX_DRM	0
+#define LV_USE_SDL		1
 ```
 
 ## Build the project
@@ -55,6 +65,11 @@ The following variables are supported.
 ### DRM/KMS
 
 - `LV_LINUX_DRM_CARD` - override default (`/dev/dri/card0`) card.
+
+### SDL2
+
+- `LV_SDL_VIDEO_WIDTH` - width of SDL2 surface (default `800`).
+- `LV_SDL_VIDEO_HEIGHT` - height of SDL2 surface (default `480`).
 
 ## Run the demo application
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # LVGL for frame buffer device
 
-Example project to use LVGL with a Linux frame buffer device, for example `/dev/fb0`.
+Example project to use LVGL with a Linux frame buffer device,
+by default `/dev/fb0`.
 
 
 Check out this blog post for a step by step tutorial:
@@ -24,6 +25,15 @@ cd build
 cmake ..
 make -j
 ```
+
+## Environment variables
+
+Environment variables can be set to modify behavior of the demo.
+The following variables are supported.
+
+### Legacy framebuffer (fbdev)
+
+- `LV_LINUX_FBDEV_DEVICE` - override default (`/dev/fb0`) framebuffer device node.
 
 ## Run the demo application
 

--- a/main.c
+++ b/main.c
@@ -9,14 +9,24 @@ static const char *getenv_default(const char *name, const char *dflt)
     return getenv(name) ? : dflt;
 }
 
-int main(void)
+#if LV_USE_LINUX_FBDEV
+static void lv_linux_disp_init(void)
 {
     const char *device = getenv_default("LV_LINUX_FBDEV_DEVICE", "/dev/fb0");
+    lv_display_t * disp = lv_linux_fbdev_create();
+
+    lv_linux_fbdev_set_file(disp, device);
+}
+#else
+#error Unsupported configuration
+#endif
+
+int main(void)
+{
     lv_init();
 
-    /*Linux frame buffer device init*/
-    lv_display_t * disp = lv_linux_fbdev_create();
-    lv_linux_fbdev_set_file(disp, device);
+    /*Linux display device init*/
+    lv_linux_disp_init();
 
     /*Create a Demo*/
     lv_demo_widgets();

--- a/main.c
+++ b/main.c
@@ -3,6 +3,8 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <time.h>
+#include <stdio.h>
+#include <stdlib.h>
 
 static const char *getenv_default(const char *name, const char *dflt)
 {

--- a/main.c
+++ b/main.c
@@ -17,6 +17,14 @@ static void lv_linux_disp_init(void)
 
     lv_linux_fbdev_set_file(disp, device);
 }
+#elif LV_USE_LINUX_DRM
+static void lv_linux_disp_init(void)
+{
+    const char *device = getenv_default("LV_LINUX_DRM_CARD", "/dev/dri/card0");
+    lv_display_t * disp = lv_linux_drm_create();
+
+    lv_linux_drm_set_file(disp, device, -1);
+}
 #else
 #error Unsupported configuration
 #endif

--- a/main.c
+++ b/main.c
@@ -25,6 +25,14 @@ static void lv_linux_disp_init(void)
 
     lv_linux_drm_set_file(disp, device, -1);
 }
+#elif LV_USE_SDL
+static void lv_linux_disp_init(void)
+{
+    const int width = atoi(getenv("LV_SDL_VIDEO_WIDTH") ? : "800");
+    const int height = atoi(getenv("LV_SDL_VIDEO_HEIGHT") ? : "480");
+
+    lv_sdl_window_create(width, height);
+}
 #else
 #error Unsupported configuration
 #endif

--- a/main.c
+++ b/main.c
@@ -4,13 +4,19 @@
 #include <pthread.h>
 #include <time.h>
 
+static const char *getenv_default(const char *name, const char *dflt)
+{
+    return getenv(name) ? : dflt;
+}
+
 int main(void)
 {
+    const char *device = getenv_default("LV_LINUX_FBDEV_DEVICE", "/dev/fb0");
     lv_init();
 
     /*Linux frame buffer device init*/
     lv_display_t * disp = lv_linux_fbdev_create();
-    lv_linux_fbdev_set_file(disp, "/dev/fb0");
+    lv_linux_fbdev_set_file(disp, device);
 
     /*Create a Demo*/
     lv_demo_widgets();


### PR DESCRIPTION
Introduce `LV_VIDEO_CARD` variable to let users specify different video device via environment variable, instead of recompiling the demo. Add DRM/KMS and SDL2 backend support, so users can test different backends.

In order to build the SDL2 backend, the lvgl submodule has to be rolled forward to newer commit ID, add commit which does that.